### PR TITLE
iOS 14 drag down animation fix

### DIFF
--- a/Source/DeckPresentationController.swift
+++ b/Source/DeckPresentationController.swift
@@ -291,13 +291,15 @@ final class DeckPresentationController: UIPresentationController, UIGestureRecog
         updateSnapshotViewAspectRatio()
         containerView.bringSubviewToFront(roundedViewForPresentedView)
         
-        if presentedViewController.view.isDescendant(of: containerView) {
-            UIView.animate(withDuration: 0.1) { [weak self] in
-                guard let `self` = self else {
-                    return
+        if #available(iOS 14, *) {} else {
+            if presentedViewController.view.isDescendant(of: containerView) {
+                UIView.animate(withDuration: 0.1) { [weak self] in
+                    guard let `self` = self else {
+                        return
+                    }
+                    
+                    self.presentedViewController.view.frame = self.frameOfPresentedViewInContainerView
                 }
-                
-                self.presentedViewController.view.frame = self.frameOfPresentedViewInContainerView
             }
         }
     }


### PR DESCRIPTION
Fixes #3037 (in pocketcasts-ios)

iOS14 no longer needs the fix for `janky' transition. In fact, this code now causes the view to be moved up to it's original position causing jumpy animation